### PR TITLE
Add --extra-args option

### DIFF
--- a/spinner/cli/main.py
+++ b/spinner/cli/main.py
@@ -6,6 +6,20 @@ import exporter.exporter as exporter
 from runner.utilities import run_benchmarks
 
 
+def parse_extra_args(extra_args):
+    args_dict = {}
+    if extra_args:
+        # Split by ';' first to handle key-value pairs
+        pairs = extra_args.split(";")
+        for pair in pairs:
+            if "=" in pair:
+                # Split by '=' to separate key and value
+                # The '1' ensures only the first '=' is split
+                key, value = pair.split("=", 1)
+                args_dict[key.strip()] = value.strip()
+    return args_dict
+
+
 @click.command()
 @click.option(
     "--config",
@@ -14,18 +28,40 @@ from runner.utilities import run_benchmarks
     type=str,
     help="Benchmark configuration file",
 )
-@click.option("--run", "-r", default=False, type=bool, help="Run all benchmarks")
 @click.option(
-    "--export", "-e", default=True, type=bool, help="Export results to report.html"
+    "--run",
+    "-r",
+    default=False,
+    is_flag=True,
+    show_default=True,
+    help="Run all benchmarks",
 )
-@click.option("--hosts", "-h", default=None, type=str, help="Hosts list")
-def cli(run, export, config, hosts):
-    main(run, export, config, hosts)
+@click.option(
+    "--export",
+    "-e",
+    default=False,
+    is_flag=True,
+    show_default=True,
+    help="Export results to report.html",
+)
+@click.option(
+    "--output", "-o", default="bench_metadata.pkl", type=str, help="Output File (.pkl)"
+)
+@click.option(
+    "--extra-args",
+    "-ea",
+    default="",
+    type=str,
+    help="Extra arguments as key=value pairs, separated by semicolons.",
+)
+def cli(run, export, config, output, extra_args):
+    extra_args_d = parse_extra_args(extra_args)
+    main(run, export, config, output, extra_args_d)
 
 
-def main(run, export, config, hosts):
+def main(run, export, config, output, extra_args):
     if run:
-        run_benchmarks(config, hosts)
+        run_benchmarks(config, output, extra_args)
 
     if export:
         reporter_path = importlib.resources.files("exporter") / "reporter.ipynb"

--- a/spinner/runner/utilities.py
+++ b/spinner/runner/utilities.py
@@ -10,15 +10,14 @@ from rich.progress import Progress
 from runner.instance_runner import InstanceRunner
 
 
-def run_benchmarks(config, hosts):
+def run_benchmarks(config, output, extra_args):
     """
     Generate execution matrix from input configuration and run all benchmarks.
     """
     bench_config = yaml.safe_load(open(config))
     bench_metadata = bench_config["metadata"]
     bench_metadata["start_timestamp"] = str(pd.Timestamp.now())
-
-    bench_metadata["hosts"] = hosts
+    bench_metadata.update(extra_args)
     bench_metadata["runner_hostname"] = str(os.uname()[1])
     bench_metadata["start_env"] = str(os.environ.copy())
 
@@ -96,5 +95,5 @@ def run_benchmarks(config, hosts):
     bench_metadata["end_env"] = str(os.environ.copy())
 
     rprint(execution_df)
-    with open("bench_metadata.pkl", "wb") as f:
+    with open(output, "wb") as f:
         pickle.dump({"metadata": bench_metadata, "dataframe": execution_df}, f)


### PR DESCRIPTION
Users can now pass additional arguments in the CLI. These arguments can be used within the command template in the spinner's YAML configuration. The --extra-args parameter accepts a list of key=value pairs, separated by semicolons.

Exemple:
```sh
host_list=$(scontrol show hostname "$SLURM_JOB_NODELIST" | tr '\n' ',' | sed 's/,$//')
images_dir="/images"
spinner -c mpich.yaml -r --extra-args 'hosts=$host_list;images=$images_dir'
```

Closes #20 