### PR TITLE
Fix extra args parsing for Spinner

### DIFF
--- a/.github/workflows/bench-example.yml
+++ b/.github/workflows/bench-example.yml
@@ -2,9 +2,9 @@ name: Spinner test
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   test:
@@ -36,6 +36,9 @@ jobs:
       - name: Extra Args comma test
         run: |
           spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=sorgan-cpu1,sorgan-cpu2"
+      - name: Extra Args list test
+        run: |
+          spinner run docs/examples/extra_args_sleep_list.yaml --extra-args 'sleep_time=[1,2]'
       - name: Capture output test
         run: |
           spinner run docs/examples/capture_output.yaml

--- a/.github/workflows/bench-example.yml
+++ b/.github/workflows/bench-example.yml
@@ -33,9 +33,12 @@ jobs:
       - name: Extra Args test
         run: |
           spinner run docs/examples/extra_args.yaml --extra-args "extra_time=4"
-      - name: Extra Args comma test
+      - name: Extra Args comma test (original hosts)
         run: |
           spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=sorgan-cpu1,sorgan-cpu2"
+      - name: Extra Args comma test (generic hosts)
+        run: |
+          spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=machineA,machineB"
       - name: Extra Args list test
         run: |
           spinner run docs/examples/extra_args_sleep_list.yaml --extra-args 'sleep_time=[1,2]'

--- a/.github/workflows/bench-example.yml
+++ b/.github/workflows/bench-example.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Extra Args test
         run: |
           spinner run docs/examples/extra_args.yaml --extra-args "extra_time=4"
+      - name: Extra Args comma test
+        run: |
+          spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=sorgan-cpu1,sorgan-cpu2"
       - name: Capture output test
         run: |
           spinner run docs/examples/capture_output.yaml

--- a/.github/workflows/bench-example.yml
+++ b/.github/workflows/bench-example.yml
@@ -33,10 +33,7 @@ jobs:
       - name: Extra Args test
         run: |
           spinner run docs/examples/extra_args.yaml --extra-args "extra_time=4"
-      - name: Extra Args comma test (original hosts)
-        run: |
-          spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=sorgan-cpu1,sorgan-cpu2"
-      - name: Extra Args comma test (generic hosts)
+      - name: Extra Args comma test
         run: |
           spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=machineA,machineB"
       - name: Extra Args list test

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -50,7 +50,24 @@ spinner run docs/examples/extra_args.yaml --extra-args "extra_time=4"
 
 Here, `extra_time=2` is added on top of `sleep_ammount`.
 
-## 4. Timeout Handling
+## 4. Extra Args with Comma Values
+
+Demonstrates passing a value that contains commas without it being split
+into a list. The command simply echoes the provided hosts string.
+
+```yaml
+--8<-- "./docs/examples/extra_args_list.yaml"
+```
+
+**How to run**:
+
+```bash
+spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=sorgan-cpu1,sorgan-cpu2"
+```
+
+The `hosts` value remains a single string and is not expanded into a list.
+
+## 5. Timeout Handling
 
 Demonstrates automatic timeout behavior. If a command exceeds the specified timeout, Spinner stops it and records a failure (optionally rerunning if `retry` is enabled).
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -62,7 +62,7 @@ into a list. The command simply echoes the provided hosts string.
 **How to run**:
 
 ```bash
-spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=sorgan-cpu1,sorgan-cpu2"
+spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=machineA,machineB"
 ```
 
 The `hosts` value remains a single string and is not expanded into a list.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -67,7 +67,22 @@ spinner run docs/examples/extra_args_list.yaml --extra-args "hosts=sorgan-cpu1,s
 
 The `hosts` value remains a single string and is not expanded into a list.
 
-## 5. Timeout Handling
+## 5. Extra Args with List Values
+
+Demonstrates passing a list of values to be swept using the `--extra-args`
+flag. Each value will result in a separate run.
+
+```yaml
+--8<-- "./docs/examples/extra_args_sleep_list.yaml"
+```
+
+**How to run**:
+
+```bash
+spinner run docs/examples/extra_args_sleep_list.yaml --extra-args 'sleep_time=[1,2]'
+```
+
+## 6. Timeout Handling
 
 Demonstrates automatic timeout behavior. If a command exceeds the specified timeout, Spinner stops it and records a failure (optionally rerunning if `retry` is enabled).
 

--- a/docs/examples/extra_args_list.yaml
+++ b/docs/examples/extra_args_list.yaml
@@ -1,0 +1,17 @@
+metadata:
+  description: Echo hosts from --extra-args flag
+  version: "1.0"
+  runs: 1
+  timeout: 10
+  retry: 1
+  envvars: [PATH, USER]
+
+applications:
+  echo_hosts:
+    command: >
+      echo {{ hosts }}
+
+benchmarks:
+  echo_hosts:
+    dummy:
+      - 0

--- a/docs/examples/extra_args_sleep_list.yaml
+++ b/docs/examples/extra_args_sleep_list.yaml
@@ -1,0 +1,17 @@
+metadata:
+  description: Sleep using a list from --extra-args
+  version: "1.0"
+  runs: 1
+  timeout: 10
+  retry: 1
+  envvars: []
+
+applications:
+  sleep_list:
+    command: >
+      sleep {{ sleep_time }}
+
+benchmarks:
+  sleep_list:
+    dummy:
+      - 0

--- a/spinner/cli/util.py
+++ b/spinner/cli/util.py
@@ -1,6 +1,7 @@
 import re
 
 import click
+import yaml
 
 
 class ExtraArgs(click.ParamType):
@@ -18,4 +19,10 @@ class ExtraArgs(click.ParamType):
             )
 
         pairs = self.parse.findall(value)
-        return {key: value for key, value in pairs}
+        result = {}
+        for key, val in pairs:
+            try:
+                result[key] = yaml.safe_load(val)
+            except Exception:
+                result[key] = val
+        return result

--- a/tests/test_extra_args.py
+++ b/tests/test_extra_args.py
@@ -16,6 +16,12 @@ def test_extra_args_parser():
     assert result == {"hosts": "sorgan-cpu1,sorgan-cpu2"}
 
 
+def test_extra_args_parser_list():
+    parser = ExtraArgs()
+    result = parser.convert("sleep_time=[1,2]", None, None)
+    assert result == {"sleep_time": [1, 2]}
+
+
 def test_sweep_parameters_with_string_extra():
     bench = SpinnerBenchmark({"node_count": [1, 2]})
     params = bench.sweep_parameters({"hosts": "sorgan-cpu1,sorgan-cpu2"})
@@ -46,3 +52,15 @@ def test_run_example_extra_args(tmp_path):
     data = pickle.loads(output.read_bytes())
     df = data["dataframe"]
     assert df["hosts"].iloc[0] == "sorgan-cpu1,sorgan-cpu2"
+
+
+def test_run_example_extra_args_list(tmp_path):
+    path = Path("docs/examples/extra_args_sleep_list.yaml")
+    config = SpinnerConfig.from_data(yaml.safe_load(path.read_text()))
+    output = tmp_path / "out.pkl"
+
+    run(SpinnerApp.get(), config, output.open("wb"), sleep_time=[1, 2])
+
+    data = pickle.loads(output.read_bytes())
+    df = data["dataframe"]
+    assert df["sleep_time"].tolist() == [1, 2]

--- a/tests/test_extra_args.py
+++ b/tests/test_extra_args.py
@@ -1,7 +1,13 @@
-import pytest
+import pickle
+from pathlib import Path
 
-from spinner.schema import SpinnerBenchmark
+import pytest
+import yaml
+
+from spinner.app import SpinnerApp
 from spinner.cli.util import ExtraArgs
+from spinner.runner import run
+from spinner.schema import SpinnerBenchmark, SpinnerConfig
 
 
 def test_extra_args_parser():
@@ -28,3 +34,15 @@ def test_sweep_parameters_with_list():
         {"sleep_amount": 2, "extra_time": 3},
         {"sleep_amount": 2, "extra_time": 4},
     ]
+
+
+def test_run_example_extra_args(tmp_path):
+    path = Path("docs/examples/extra_args_list.yaml")
+    config = SpinnerConfig.from_data(yaml.safe_load(path.read_text()))
+    output = tmp_path / "out.pkl"
+
+    run(SpinnerApp.get(), config, output.open("wb"), hosts="sorgan-cpu1,sorgan-cpu2")
+
+    data = pickle.loads(output.read_bytes())
+    df = data["dataframe"]
+    assert df["hosts"].iloc[0] == "sorgan-cpu1,sorgan-cpu2"

--- a/tests/test_extra_args.py
+++ b/tests/test_extra_args.py
@@ -12,8 +12,8 @@ from spinner.schema import SpinnerBenchmark, SpinnerConfig
 
 def test_extra_args_parser():
     parser = ExtraArgs()
-    result = parser.convert("hosts=sorgan-cpu1,sorgan-cpu2", None, None)
-    assert result == {"hosts": "sorgan-cpu1,sorgan-cpu2"}
+    result = parser.convert("hosts=machineA,machineB", None, None)
+    assert result == {"hosts": "machineA,machineB"}
 
 
 def test_extra_args_parser_list():
@@ -24,10 +24,10 @@ def test_extra_args_parser_list():
 
 def test_sweep_parameters_with_string_extra():
     bench = SpinnerBenchmark({"node_count": [1, 2]})
-    params = bench.sweep_parameters({"hosts": "sorgan-cpu1,sorgan-cpu2"})
+    params = bench.sweep_parameters({"hosts": "machineA,machineB"})
     assert params == [
-        {"node_count": 1, "hosts": "sorgan-cpu1,sorgan-cpu2"},
-        {"node_count": 2, "hosts": "sorgan-cpu1,sorgan-cpu2"},
+        {"node_count": 1, "hosts": "machineA,machineB"},
+        {"node_count": 2, "hosts": "machineA,machineB"},
     ]
 
 
@@ -47,11 +47,11 @@ def test_run_example_extra_args(tmp_path):
     config = SpinnerConfig.from_data(yaml.safe_load(path.read_text()))
     output = tmp_path / "out.pkl"
 
-    run(SpinnerApp.get(), config, output.open("wb"), hosts="sorgan-cpu1,sorgan-cpu2")
+    run(SpinnerApp.get(), config, output.open("wb"), hosts="machineA,machineB")
 
     data = pickle.loads(output.read_bytes())
     df = data["dataframe"]
-    assert df["hosts"].iloc[0] == "sorgan-cpu1,sorgan-cpu2"
+    assert df["hosts"].iloc[0] == "machineA,machineB"
 
 
 def test_run_example_extra_args_list(tmp_path):

--- a/tests/test_extra_args.py
+++ b/tests/test_extra_args.py
@@ -1,0 +1,30 @@
+import pytest
+
+from spinner.schema import SpinnerBenchmark
+from spinner.cli.util import ExtraArgs
+
+
+def test_extra_args_parser():
+    parser = ExtraArgs()
+    result = parser.convert("hosts=sorgan-cpu1,sorgan-cpu2", None, None)
+    assert result == {"hosts": "sorgan-cpu1,sorgan-cpu2"}
+
+
+def test_sweep_parameters_with_string_extra():
+    bench = SpinnerBenchmark({"node_count": [1, 2]})
+    params = bench.sweep_parameters({"hosts": "sorgan-cpu1,sorgan-cpu2"})
+    assert params == [
+        {"node_count": 1, "hosts": "sorgan-cpu1,sorgan-cpu2"},
+        {"node_count": 2, "hosts": "sorgan-cpu1,sorgan-cpu2"},
+    ]
+
+
+def test_sweep_parameters_with_list():
+    bench = SpinnerBenchmark({"sleep_amount": [1, 2]})
+    params = bench.sweep_parameters({"extra_time": [3, 4]})
+    assert params == [
+        {"sleep_amount": 1, "extra_time": 3},
+        {"sleep_amount": 1, "extra_time": 4},
+        {"sleep_amount": 2, "extra_time": 3},
+        {"sleep_amount": 2, "extra_time": 4},
+    ]


### PR DESCRIPTION
## Summary
- handle string values correctly in `SpinnerBenchmark.sweep_parameters`
- add tests for `ExtraArgs` parsing and sweep with fixed values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e95054288330953149af71001f5d