### PR TITLE
Make notebook dependencies optional

### DIFF
--- a/.github/workflows/bench-example.yml
+++ b/.github/workflows/bench-example.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           spinner run docs/examples/capture_output.yaml
 
-  notebook:
+  exporter:
     runs-on: ubuntu-latest
     needs: test
     strategy:
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install ".[dev,notebook]"
+          python -m pip install ".[dev,exporter]"
       - name: Sleep and plot
         run: |
           spinner run docs/examples/sleep_plot.yaml -o output.pkl

--- a/.github/workflows/bench-example.yml
+++ b/.github/workflows/bench-example.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -16,36 +15,55 @@ jobs:
         python-version: ["3.11"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install ".[dev]"
-    - name: Basic benchmark test
-      run: |
-         spinner run docs/examples/sleep_benchmark.yaml
-    - name: Sleep and plot
-      run: |
-         spinner run docs/examples/sleep_plot.yaml -o output.pkl
-         spinner export -i output.pkl
-    - name: Timeout test
-      run: |
-         spinner run docs/examples/timeout_test.yaml
-    - name: Extra Args test
-      run: |
-         spinner run docs/examples/extra_args.yaml --extra-args "extra_time=4"
-    - name: Capture output test
-      run: |
-         spinner run docs/examples/capture_output.yaml
-    - name: upload produced graphs
-      uses: actions/upload-artifact@v4
-      with:
-        name: generated graphs
-        path: |
-          benchdata.html
-          benchdata.ipynb
-          output-benchdata/
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev]"
+      - name: Basic benchmark test
+        run: |
+          spinner run docs/examples/sleep_benchmark.yaml
+      - name: Timeout test
+        run: |
+          spinner run docs/examples/timeout_test.yaml
+      - name: Extra Args test
+        run: |
+          spinner run docs/examples/extra_args.yaml --extra-args "extra_time=4"
+      - name: Capture output test
+        run: |
+          spinner run docs/examples/capture_output.yaml
+
+  notebook:
+    runs-on: ubuntu-latest
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev,notebook]"
+      - name: Sleep and plot
+        run: |
+          spinner run docs/examples/sleep_plot.yaml -o output.pkl
+          spinner export -i output.pkl
+      - name: upload produced graphs
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated graphs
+          path: |
+            benchdata.html
+            benchdata.ipynb
+            output-benchdata/

--- a/.github/workflows/package-path.yml
+++ b/.github/workflows/package-path.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install ".[notebook]"
+        python -m pip install ".[exporter]"
         mkdir other-folder
     - name: Sleep and plot
       run: |

--- a/.github/workflows/package-path.yml
+++ b/.github/workflows/package-path.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install "."
+        python -m pip install ".[notebook]"
         mkdir other-folder
     - name: Sleep and plot
       run: |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install spinner
 To enable the optional export features that rely on Jupyter, install with:
 
 ```bash
-pip install 'spinner[notebook]'
+pip install 'spinner[exporter]'
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Spinner is distributed as a Python package and can be installed via `pip`:
 pip install spinner
 ```
 
+To enable the optional export features that rely on Jupyter, install with:
+
+```bash
+pip install 'spinner[notebook]'
+```
+
 ## Contributing
 
 To learn how to set up your development environment and contribute to Spinner, please refer to the [Contribution Guidelines](docs/contribute.md).

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -163,7 +163,7 @@ git tag -d v0.0.2
   - **MINOR** version when you add functionality in a backwards-compatible manner.  
   - **PATCH** version when you make backwards-compatible bug fixes.
 
-- **Pre-releases**: If you want to test a release or offer a release candidate, append `.devX` or `rcX` (e.g., `v1.2.3.dev1` or `v1.2.3rc1`). This is valid for `setuptools_scm` and won’t break the build.
+- **Pre-releases**: If you want to test a release or offer a release candidate, append `.devX`, `bX`, or `rcX` (e.g., `v1.2.3.dev1`, `v1.2.0b1`, or `v1.2.3rc1`). This is valid for `setuptools_scm` and won’t break the build.
 
 - **Annotated Tags**: Use annotated tags to include additional metadata such as the tagger name, email, date, and a message:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ python3 -m pip install pip --upgrade
    Jupyter dependencies:
 
    ```bash
-   pip install 'spinner[notebook]'
+   pip install 'spinner[exporter]'
    ```
 
 2. **Create a YAML file** defining parameters and commands. For a minimal example:

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,13 @@ python3 -m pip install pip --upgrade
    pip install spinner
    ```
 
+   To use the `spinner export` command you will also need the optional
+   Jupyter dependencies:
+
+   ```bash
+   pip install 'spinner[notebook]'
+   ```
+
 2. **Create a YAML file** defining parameters and commands. For a minimal example:
 
    ```yaml

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -164,7 +164,7 @@ The export command relies on Jupyter and plotting libraries that are not
 installed with the minimal package. Install them via:
 
 ```bash
-pip install 'spinner[notebook]'
+pip install 'spinner[exporter]'
 ```
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -160,6 +160,13 @@ Spinner builds the Cartesian product of every parameter list. Two params with th
 
 ## Spinner Export
 
+The export command relies on Jupyter and plotting libraries that are not
+installed with the minimal package. Install them via:
+
+```bash
+pip install 'spinner[notebook]'
+```
+
 ```bash
 spinner export -i output.pkl
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.9.12, <4"
 dependencies = [
     "click~=8.1",
     "jinja2~=3.1",
+    "pyyaml~=6.0",
     "numpy~=2.2",
     "pandas~=2.2",
     "pydantic~=2.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ docs = [
     "mkdocs-material==9.5.40",
     "mkdocs-include-markdown-plugin==7.1.5",
 ]
-notebook = [
+exporter = [
     "ipykernel~=6.29",
     "nbconvert~=7.16",
     "nbformat~=5.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,16 +10,11 @@ dynamic = ["version"]
 requires-python = ">=3.9.12, <4"
 dependencies = [
     "click~=8.1",
-    "ipykernel~=6.29",
     "jinja2~=3.1",
-    "jupyter~=1.1",
-    "matplotlib~=3.10",
     "numpy~=2.2",
     "pandas~=2.2",
     "pydantic~=2.10",
     "rich~=13.9",
-    "scipy~=1.15",
-    "seaborn~=0.13",
     "tokenize-rt~=6.1",
 ]
 
@@ -35,6 +30,14 @@ docs = [
     "mkdocs==1.6.1",
     "mkdocs-material==9.5.40",
     "mkdocs-include-markdown-plugin==7.1.5",
+]
+notebook = [
+    "ipykernel~=6.29",
+    "nbconvert~=7.16",
+    "nbformat~=5.10",
+    "matplotlib~=3.10",
+    "scipy~=1.15",
+    "seaborn~=0.13",
 ]
 
 [project.scripts]

--- a/spinner/__init__.py
+++ b/spinner/__init__.py
@@ -1,3 +1,7 @@
 from . import cli as cli
-from . import exporter as exporter
 from . import runner as runner
+
+__all__ = [
+    "cli",
+    "runner",
+]

--- a/spinner/cli/main.py
+++ b/spinner/cli/main.py
@@ -71,7 +71,15 @@ def run(app, config, output, extra_args) -> None:
 def export(app, input) -> None:
     """Export benchmark data."""
     path = importlib.resources.files("spinner.exporter") / "reporter.ipynb"
-    spinner.exporter.run(path, pkl_db_path=os.path.abspath(input.name))
+    try:
+        exporter = importlib.import_module("spinner.exporter")
+        exporter.run(path, pkl_db_path=os.path.abspath(input.name))
+    except (ImportError, RuntimeError) as error:
+        app.print(
+            "[b red]ERROR[/]: Export requires optional Jupyter dependencies.\n"
+            "Install them with 'pip install spinner[notebook]'."
+        )
+        raise SystemExit(1) from error
 
 
 def main():

--- a/spinner/cli/main.py
+++ b/spinner/cli/main.py
@@ -77,7 +77,7 @@ def export(app, input) -> None:
     except (ImportError, RuntimeError) as error:
         app.print(
             "[b red]ERROR[/]: Export requires optional Jupyter dependencies.\n"
-            "Install them with 'pip install spinner[notebook]'."
+            "Install them with 'pip install spinner[exporter]'."
         )
         raise SystemExit(1) from error
 

--- a/spinner/exporter/__init__.py
+++ b/spinner/exporter/__init__.py
@@ -4,7 +4,7 @@ def run(*args, **kwargs):
     except ImportError as exc:  # pragma: no cover - runtime check
         raise RuntimeError(
             "Export requires optional Jupyter dependencies. "
-            "Install with `pip install spinner[notebook]`."
+            "Install with `pip install spinner[exporter]`."
         ) from exc
 
     return run_reporter(*args, **kwargs)

--- a/spinner/exporter/__init__.py
+++ b/spinner/exporter/__init__.py
@@ -1,5 +1,13 @@
-from .exporter import run_reporter as run
+def run(*args, **kwargs):
+    try:
+        from .exporter import run_reporter
+    except ImportError as exc:  # pragma: no cover - runtime check
+        raise RuntimeError(
+            "Export requires optional Jupyter dependencies. "
+            "Install with `pip install spinner[notebook]`."
+        ) from exc
 
-__all__ = [
-    "run",
-]
+    return run_reporter(*args, **kwargs)
+
+
+__all__ = ["run"]


### PR DESCRIPTION
## Summary
- make the Jupyter notebook stack optional
- provide helpful message when export is used without optional deps
- document optional installation and beta tags

## Testing
- `black . && isort .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68470200d6548330a4f2fa5990640626