### PR TITLE
Add capture-all support

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,6 +100,16 @@ capture:
       )
 ```
 
+To capture the entire stdout/stderr text without parsing, you can use `type: all`:
+
+```yaml
+capture:
+  - type: all
+    name: raw_output
+```
+
+See `tests/test_capture_all.py` for a working example.
+
 ##### plot
 
 The `plot` section provides a minimal configuration to generate quick visualizations of the collected results. Each entry defines a plot with `x_axis` and `y_axis`, which must reference existing columns in the dataframe. Optionally, a `group_by` field allows aggregation (via mean) across runs with the same value for that key, useful for summarizing repeated experiments. These plots serve as a quick-look feature, and the real customization is intended to happen later in the exported Jupyter notebook, where users can modify and extend the visualization logic freely.

--- a/spinner/schema.py
+++ b/spinner/schema.py
@@ -126,11 +126,9 @@ class SpinnerLambda(RootModel):
 class SpinnerCaptureAll(BaseModel):
     type: Literal["all"]
     name: str
-    func: SpinnerLambda = Field(alias="lambda")
 
     def process(self, input: str) -> tuple[str, Any]:
-        capture = None
-        return self.name, capture
+        return self.name, input
 
 
 class SpinnerCaptureMatches(BaseModel):

--- a/tests/test_capture_all.py
+++ b/tests/test_capture_all.py
@@ -1,0 +1,40 @@
+import pickle
+
+from spinner.app import SpinnerApp
+from spinner.runner import run
+from spinner.schema import SpinnerConfig
+
+
+def test_capture_all_basic(tmp_path):
+    config = SpinnerConfig.from_data(
+        {
+            "metadata": {
+                "description": "capture all",
+                "version": "1.0",
+                "runs": 1,
+                "timeout": 5,
+                "retry": 0,
+                "envvars": [],
+            },
+            "applications": {
+                "echo": {
+                    "command": "echo hello",
+                    "capture": [
+                        {
+                            "type": "all",
+                            "name": "raw_output",
+                        }
+                    ],
+                }
+            },
+            "benchmarks": {"echo": {}},
+        }
+    )
+
+    output = tmp_path / "out.pkl"
+    run(SpinnerApp.get(), config, output.open("wb"))
+
+    data = pickle.loads(output.read_bytes())
+    df = data["dataframe"]
+    assert df["raw_output"].iloc[0].strip() == "hello"
+


### PR DESCRIPTION
Fix capture:all that was broken.


- process all output with given lambda in `SpinnerCaptureAll`
- document `type: all` usage
- test capture-all behaviour